### PR TITLE
Deprecate python=3.9, update dependencies, and fix expand_pd bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -54,7 +54,7 @@ jobs:
         run: sudo apt-get install pandoc
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ matrix.python_version }}
           cache: "pip"
@@ -101,7 +101,7 @@ jobs:
         run: sudo apt-get install pandoc
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ ignore = [
     "PD901",   # pandas-df-variable-name
     "PERF203", # try-except-in-loop
     "PERF401", # manual-list-comprehension (TODO fix these or wait for autofix)
+    "PLC0206",
     "PLR",     # pylint-refactor
     "PLW2901", # Outer for loop variable overwritten by inner assignment target
     "PT006",   # pytest-parametrize-names-wrong-type


### PR DESCRIPTION
Triggers release based on most recent commits. Fixes bug in expand_pd when working with grand potential phase diagrams.

Also updates to require python=3.10, with new dependencies. Addresses current issue with latest pymongo also by pinning version (will fix this later!)